### PR TITLE
Fix Repository typo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Remi Rampin <remirampin@gmail.com>"]
 description = "Content-defined chunking"
 documentation = "https://remram44.github.io/cdchunking-rs/index.html"
 readme = "README.md"
-repository = "https://github.com.remram44/cdchunking-rs"
+repository = "https://github.com/remram44/cdchunking-rs"
 keywords = ["chunks", "cdc", "content", "defined", "chunking"]
 license = "MIT"
 


### PR DESCRIPTION
Had a little trouble reaching the repo at first, so thought id throw in the quick fix.